### PR TITLE
Update the cluster CA issuer

### DIFF
--- a/stable/search-prod/templates/_helpers.tpl
+++ b/stable/search-prod/templates/_helpers.tpl
@@ -34,10 +34,3 @@ Create chart name and version as used by the chart label.
 {{- define "search.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Create managedBy for labels
-*/}}
-{{- define "search.managedBy" -}}
-{{- printf "MCMCP" -}}
-{{- end -}}

--- a/stable/search-prod/templates/redisgraph-certificate.yaml
+++ b/stable/search-prod/templates/redisgraph-certificate.yaml
@@ -15,11 +15,11 @@ metadata:
 spec:
   secretName: {{ .Release.Name }}-redisgraph-secrets
   issuerRef:
-    name: icp-ca-issuer
+    name: {{ .Values.global.clusterCAIssuer }}
     kind: ClusterIssuer
   commonName: search-redisgraph
   dnsNames:
   - {{ template "search.fullname" . }}-search-redisgraph
   isCA: true
   organization:
-  - IBM
+  - Red Hat

--- a/stable/search-prod/templates/search-api-certificate.yaml
+++ b/stable/search-prod/templates/search-api-certificate.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   secretName: {{ .Release.Name }}-search-api-secrets
   issuerRef:
-    name: icp-ca-issuer
+    name: {{ .Values.global.clusterCAIssuer }}
     kind: ClusterIssuer
   commonName: search-api
   dnsNames:
@@ -24,4 +24,4 @@ spec:
   - {{ template "search.fullname" . }}-search-api.{{ .Release.Namespace }}.svc
   isCA: true
   organization:
-  - IBM
+  - Red Hat

--- a/stable/search-prod/templates/search-certificate.yaml
+++ b/stable/search-prod/templates/search-certificate.yaml
@@ -15,11 +15,11 @@ metadata:
 spec:
   secretName: {{ .Release.Name }}-search-secrets
   issuerRef:
-    name: icp-ca-issuer
+    name: {{ .Values.global.clusterCAIssuer }}
     kind: ClusterIssuer
   commonName: search-aggregator
   dnsNames:
   - {{ template "search.fullname" . }}-search-aggregator
   isCA: true
   organization:
-  - IBM
+  - Red Hat

--- a/stable/search-prod/templates/search-tiller-client-certs.yaml
+++ b/stable/search-prod/templates/search-tiller-client-certs.yaml
@@ -18,6 +18,6 @@ spec:
   - system:masters
   issuerRef:
     kind: ClusterIssuer
-    name: icp-ca-issuer
+    name: {{ .Values.global.clusterCAIssuer }}
   secretName: {{ .Release.Name }}-tiller-client-certs
 

--- a/stable/search-prod/values-metadata.yaml
+++ b/stable/search-prod/values-metadata.yaml
@@ -224,6 +224,12 @@ imageTagPostfix:
 global:
   arch:
     type: options
+  cfcRouterUrl:
+    type: string
+  clusterCAIssuer:
+    label: "Cluster CA Issuer"
+    description: "Root CA to sign the certificates for the search services"
+    type: string
   nodeSelector:
     os:
       type: string
@@ -233,8 +239,6 @@ global:
       type: string
     enabled:
       type: boolean
-  cfcRouterUrl:
-     type: string
   __metadata:
     label: "Global Settings for Search"
     description: "Global Settings for Search Chart Deployment"

--- a/stable/search-prod/values.yaml
+++ b/stable/search-prod/values.yaml
@@ -13,13 +13,13 @@ global:
   - amd64
   - ppc64le
   - s390x
-
+  cfcRouterUrl: "https://icp-management-ingress:443"
+  clusterCAIssuer: multicloud-ca-issuer
   nodeSelector:
     enabled: false
     os: ""
     customLabelSelector: ""
     customLabelValue: ""
-  cfcRouterUrl: "https://icp-management-ingress:443"
   tillerIntegration:
     user: null
 


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/404

Updates the default cluster CA Issuer.  Also adds an option to override it from when installing the chart.