### PR TITLE
Fix a secret name change

### DIFF
--- a/stable/search-prod/templates/search-aggregator-deployment.yaml
+++ b/stable/search-prod/templates/search-aggregator-deployment.yaml
@@ -104,7 +104,7 @@ spec:
       volumes:
       - name: icp-search-certs
         secret:
-          secretName: {{ .Release.Name }}-search-secrets
+          secretName: search-aggregator-secrets
       - name: redis-graph-certs
         secret:
           secretName: {{ .Release.Name }}-redisgraph-secrets


### PR DESCRIPTION
The name for the aggregate secret changed in the previous pull request from search-prod-UUID-search-secrets to search-aggregator-secret