### PR TITLE
Remove isCA flags from generated certificates

### DIFF
--- a/stable/search-prod/templates/redisgraph-certificate.yaml
+++ b/stable/search-prod/templates/redisgraph-certificate.yaml
@@ -1,6 +1,7 @@
 # Licensed Materials - Property of IBM
 # (C) Copyright IBM Corporation 2019 All Rights Reserved
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate

--- a/stable/search-prod/templates/search-aggregator-certificate.yaml
+++ b/stable/search-prod/templates/search-aggregator-certificate.yaml
@@ -1,6 +1,7 @@
 # Licensed Materials - Property of IBM
 # (C) Copyright IBM Corporation 2019 All Rights Reserved
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate

--- a/stable/search-prod/templates/search-api-certificate.yaml
+++ b/stable/search-prod/templates/search-api-certificate.yaml
@@ -1,6 +1,7 @@
 # Licensed Materials - Property of IBM
 # (C) Copyright IBM Corporation 2019 All Rights Reserved
 # US Government Users Restricted Rights - Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# Copyright (c) 2020 Red Hat, Inc.
 
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/1457

Search components aren't certificate signers, so we shouldn't use the `isCA` flag when generating these certificates.