### PR TITLE
Add sessionAffinity to search-api service

### DIFF
--- a/stable/search-prod/templates/api-service.yaml
+++ b/stable/search-prod/templates/api-service.yaml
@@ -22,3 +22,4 @@ spec:
     app: {{ .Values.search.name }}
     component: "search-api"
     release: {{ .Release.Name }}
+  sessionAffinity: ClientIP


### PR DESCRIPTION
The `search-api` caches the user RBAC filter.  With multiple replicas, we need to use `sessionAffinity` to ensure that requests from a given client continue being routed to the same pod to benefit from the previously cached settings.

This graph validates that request from a single user always get routed to the same pod (yellow). We see that load balancing is still in effect when I asked other users to log in, around 10:50
![image](https://user-images.githubusercontent.com/4671325/86294399-763d4d80-bbc2-11ea-9dcf-29b7a47d6b2c.png)