### PR TITLE
Reduce search-operator role privileges

### DIFF
--- a/stable/search-prod/templates/operator-role.yaml
+++ b/stable/search-prod/templates/operator-role.yaml
@@ -51,3 +51,4 @@ rules:
   - create
   - list
   - watch
+  - update


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/3170

Reduces the privileged granted to the search-operator role.

Tested on cluster `jpadilla-test`