### PR TITLE
Increase operator memory limits

### DIFF
--- a/stable/search-prod/values.yaml
+++ b/stable/search-prod/values.yaml
@@ -95,4 +95,4 @@ search:
         memory: "32Mi"
         cpu: "10m"
       limits:
-        memory: "128Mi"
+        memory: "256Mi"


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1882748

Increase the search-operator memory limit until we can figure out why some clusters require more when the pod first starts. This is a workaround to mitigate the problem.
