### PR TITLE
Increase default mem request for redisgraph and search-api

### DIFF
--- a/stable/search-prod/values.yaml
+++ b/stable/search-prod/values.yaml
@@ -78,14 +78,14 @@ search:
   searchapi:
     resources:
       requests:
-        memory: "64Mi"
+        memory: "128Mi"
         cpu: "25m"
       limits:
         memory: "1024Mi"
   redisgraph:
     resources:
       requests:
-        memory: "64Mi"
+        memory: "128Mi"
         cpu: "25m"
       limits:
         memory: "1024Mi"


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/6974

In a cluster with minimal load, the search-api is above the requested 64Mi, so increasing to 128Mi to prevent evictions.

![image](https://user-images.githubusercontent.com/4671325/98989321-f2dc2300-24f6-11eb-8d1e-98fd6586351b.png)

![image](https://user-images.githubusercontent.com/4671325/98989392-0ab3a700-24f7-11eb-993b-986415ce63f4.png)
