### PR TITLE
Fix operator deployment

### DIFF
--- a/stable/search-prod/templates/operator-deployment.yaml
+++ b/stable/search-prod/templates/operator-deployment.yaml
@@ -18,20 +18,21 @@ spec:
       containers:
       - args:
         - --enable-leader-election
-        command: /manager 
-        - name: search-operator
-          image: {{ .Values.global.imageOverrides.search_operator }}
-          imagePullPolicy: {{ .Values.global.pullPolicy }}
-          env:
-            - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: OPERATOR_NAME
-              value: "search-operator"
-          resources:
-{{ toYaml .Values.search.operator.resources | indent 12 }}
+        command:
+        - /manager 
+        name: search-operator
+        image: {{ .Values.global.imageOverrides.search_operator }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OPERATOR_NAME
+            value: "search-operator"
+        resources:
+{{ toYaml .Values.search.operator.resources | indent 10 }}


### PR DESCRIPTION
Fixes issue:

```
message: 'failed to install release: unable to build kubernetes objects
                from release manifest: error validating "": error validating data:
                [ValidationError(Deployment.spec.template.spec.containers[0].command[1]):
                invalid type for io.k8s.api.core.v1.Container.command: got "map",
                expected "string", ValidationError(Deployment.spec.template.spec.containers[0]):
                missing required field "name" in io.k8s.api.core.v1.Container]'
```