### PR TITLE
Add ingress for overview and resources

### DIFF
--- a/stable/search-prod/templates/ui-ingress.yaml
+++ b/stable/search-prod/templates/ui-ingress.yaml
@@ -21,3 +21,12 @@ spec:
         backend:
           serviceName: search-ui
           servicePort: 3000
+      - path: /overview
+        backend:
+          serviceName: search-ui
+          servicePort: 3000
+      - path: /resources
+        backend:
+          serviceName: search-ui
+          servicePort: 3000
+      


### PR DESCRIPTION
Issues:
- https://github.com/open-cluster-management/backlog/issues/6480
- https://github.com/open-cluster-management/backlog/issues/6479

## Changes:
- Adds and ingress rule for the routes `/overview` and `/resources`