### PR TITLE
Remove unused env on search-ui

### DIFF
--- a/stable/search-prod/templates/ui-deployment.yaml
+++ b/stable/search-prod/templates/ui-deployment.yaml
@@ -70,14 +70,10 @@ spec:
           value: https://console-api:4000/hcmuiapi
         - name: FRONTEND_URL
           value: "https://multicloud-console.{{ .Values.ocpingress }}/search/"
-        - name: BACKEND_URL
-          value: "https://multicloud-console.{{ .Values.ocpingress }}/search/"
         - name: OAUTH2_REDIRECT_URL
           value: https://multicloud-console.{{ .Values.ocpingress }}/search/login/callback
         - name: PORT
           value: '3000'
-        - name: cfcRouterUrl
-          value: {{ .Values.cfcRouterUrl }}
         ports:
         - containerPort: 3000
           protocol: TCP


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/search-ui/pull/34

## Changes:
- Removes unused env from the search-ui deployment