### PR TITLE
add stable-repo-url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ default::
 
 init::
 	curl -fksSL https://storage.googleapis.com/kubernetes-helm/helm-v2.14.1-linux-amd64.tar.gz | sudo tar --strip-components=1 -xvz -C /usr/local/bin/ linux-amd64/helm
-	helm init -c
+	helm init --stable-repo-url https://charts.helm.sh/stable -c
 
 lint:
 	@mkdir -p $(STABLE_BUILD_DIR)


### PR DESCRIPTION
check if 403 error in [build](https://travis-ci.com/github/open-cluster-management/search-chart/jobs/463674997) is fixed
Trying solution from [here](https://stackoverflow.com/questions/61954440/how-to-resolve-https-kubernetes-charts-storage-googleapis-com-is-not-a-valid)