### PR TITLE
add lease rbac for work-manger addon agent in ocp 311 case

### DIFF
--- a/stable/search-prod/templates/addon-role.yaml
+++ b/stable/search-prod/templates/addon-role.yaml
@@ -11,3 +11,14 @@ rules:
       - proxy.open-cluster-management.io
     resources:
       - clusterstatuses/aggregator
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - create


### PR DESCRIPTION
related issue: https://github.com/stolostron/backlog/issues/21190
the issue is for work-manager, but I found search addon also miss this rbac.
there is no lease in OCP 311, so need to create lease on the hub cluster.
Signed-off-by: Zhiwei Yin <zyin@redhat.com>