### PR TITLE
[2.4] Adding POD_NAMESPACE env var 

### DIFF
--- a/stable/search-prod/templates/collector-deployment.yaml
+++ b/stable/search-prod/templates/collector-deployment.yaml
@@ -75,6 +75,10 @@ spec:
           value: local-cluster
         - name: AGGREGATOR_URL
           value: 'https://search-aggregator.{{ .Release.Namespace }}.svc:3010'
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         resources:
 {{ toYaml .Values.search.collector.resources | indent 10 }}
         livenessProbe:


### PR DESCRIPTION
Signed-off-by: Anxhela <acoba@redhat.com>

Related: https://github.com/stolostron/backlog/issues/20225

Allow/deny api needs to pick up the pod's namespace so we add an env variable to search chart within collector deployment.